### PR TITLE
feat: add `bin` and usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,38 @@ The TSTyche reporter for IntelliJ IDEA, WebStorm and other JetBrains IDEs.
 
 This reporter will be used by the `intellij-tstyche` plugin (work in progress).
 
+## Usage
+
+You can help to test the reporter before the plugin is released.
+
+### Requirements
+
+The reporter expects TSTyche version `3.5` or above to be installed. The minimum required Node.js version is `20.9`.
+
+### Setup
+
+Install the package:
+
+```shell
+npm add -D tstyche-intellij-reporter
+```
+
+Create a new Run Configuration:
+
+<!-- TODO add image -->
+
+Run your type tests:
+
+<!-- TODO add image -->
+
+### Limitations
+
+The reporter is responsible to output the results of test runs. It cannot provide plugin specific features. Therefor:
+
+- gutter run icons are not supported,
+- rerun failed tests action does not work,
+- the command line options are ignored (except `--watch`).
+
 ## License
 
 [MIT][license-url] © TSTyche

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import process from "node:process";
+import { Cli } from "tstyche/tstyche";
+
+const intellijReporter = new URL("./lib/IntellijReporter.js", import.meta.url).toString();
+
+const commandLine = ["--reporters", intellijReporter];
+
+if (process.argv.includes("--watch")) {
+  commandLine.push("--watch");
+}
+
+const cli = new Cli();
+
+await cli.run(commandLine);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ".": "./lib/IntellijReporter.js",
     "./package.json": "./package.json"
   },
+  "bin": "./bin.js",
   "files": [
     "lib/*"
   ],


### PR DESCRIPTION
@rickosborne Thanks for the work you have done trying to have better integration between TSTyche and JetBrains. The comments you wrote on the way helped me a lot. Building a plugin was in my plans, but it was not clear where to start.

As I was mentioning, this project is TSTyche reporter for IntelliJ based IDEs:

<img width="1010" alt="Screenshot 2025-01-14 at 10 26 21" src="https://github.com/user-attachments/assets/eef40830-efe2-439d-93eb-d7fc69dadbef" />

---

It does not have a `bin` entry. I wanted to ask your opinion, which solution sounds more optimal:

- creating a separate wrapper, like `tstyche-as-mocha`,
- or including it here and publishing this package to `npm`.

This PR is meant to add the `bin` entry. As you can see, currently these are only 15 lines.

I was using this implementation with Mocha’s and Jest’s run configurations. It seemed reasonable to support `--watch` flag, but to ignore all others. Because flags like `--grep` differ a lot between runners. I would better spend that time building TSTyche plugin. Starting from Run Configuration as the first step.

What do you think?

Also could I ask to try out the reporter? It might be I have missed something. 